### PR TITLE
Add Firebase user list with filtering

### DIFF
--- a/app/src/main/java/com/codespacepro/whatsify/Activities/NewChatActivity.java
+++ b/app/src/main/java/com/codespacepro/whatsify/Activities/NewChatActivity.java
@@ -2,6 +2,12 @@ package com.codespacepro.whatsify.Activities;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.ProgressBar;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
@@ -11,6 +17,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.codespacepro.whatsify.Adapters.ChatAdapter;
 import com.codespacepro.whatsify.Models.Chat;
 import com.codespacepro.whatsify.R;
+import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
@@ -22,9 +29,15 @@ import java.util.List;
 
 public class NewChatActivity extends AppCompatActivity {
 
-    RecyclerView recyclerView;
-    List<Chat> users = new ArrayList<>();
-    DatabaseReference ref;
+    private RecyclerView recyclerView;
+    private ProgressBar progressBar;
+    private TextView emptyView;
+    private EditText searchBar;
+
+    private final List<Chat> users = new ArrayList<>();
+    private final List<Chat> filteredUsers = new ArrayList<>();
+    private DatabaseReference ref;
+    private ValueEventListener userListener;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -32,15 +45,21 @@ public class NewChatActivity extends AppCompatActivity {
         setContentView(R.layout.activity_new_chat);
 
         recyclerView = findViewById(R.id.new_chat_list);
+        progressBar = findViewById(R.id.progress);
+        emptyView = findViewById(R.id.empty_view);
+        searchBar = findViewById(R.id.search_bar);
+
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
 
         ref = FirebaseDatabase.getInstance().getReference().child("Users");
 
-        ref.addValueEventListener(new ValueEventListener() {
+        userListener = new ValueEventListener() {
             @Override
             public void onDataChange(@NonNull DataSnapshot snapshot) {
                 users.clear();
+                String currentUid = FirebaseAuth.getInstance().getUid();
                 for (DataSnapshot snap : snapshot.getChildren()) {
+                    if (snap.getKey() == null || snap.getKey().equals(currentUid)) continue;
                     if (snap.hasChild("email") && snap.hasChild("fullname")) {
                         String email = snap.child("email").getValue(String.class);
                         String fullname = snap.child("fullname").getValue(String.class);
@@ -48,18 +67,63 @@ public class NewChatActivity extends AppCompatActivity {
                         users.add(new Chat(uid, email, fullname));
                     }
                 }
-                recyclerView.setAdapter(new ChatAdapter(NewChatActivity.this, users, chat -> {
-                    Intent intent = new Intent(NewChatActivity.this, ChatActivity.class);
-                    intent.putExtra("receiverId", chat.getUid());
-                    startActivity(intent);
-                    finish();
-                }));
+                applyFilter(searchBar.getText().toString());
+                progressBar.setVisibility(View.GONE);
             }
 
             @Override
             public void onCancelled(@NonNull DatabaseError error) {
+                progressBar.setVisibility(View.GONE);
+                emptyView.setVisibility(View.VISIBLE);
+                emptyView.setText("Failed to load users");
+            }
+        };
 
+        progressBar.setVisibility(View.VISIBLE);
+        ref.addValueEventListener(userListener);
+
+        searchBar.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                applyFilter(s.toString());
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
             }
         });
+    }
+
+    private void applyFilter(String query) {
+        filteredUsers.clear();
+        if (query == null) query = "";
+        String lower = query.toLowerCase();
+        for (Chat chat : users) {
+            if (chat.getFullname() != null && chat.getFullname().toLowerCase().contains(lower)) {
+                filteredUsers.add(chat);
+            }
+        }
+        if (filteredUsers.isEmpty()) {
+            emptyView.setVisibility(View.VISIBLE);
+        } else {
+            emptyView.setVisibility(View.GONE);
+        }
+        recyclerView.setAdapter(new ChatAdapter(NewChatActivity.this, filteredUsers, chat -> {
+            Intent intent = new Intent(NewChatActivity.this, ChatActivity.class);
+            intent.putExtra("receiverId", chat.getUid());
+            startActivity(intent);
+        }));
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (ref != null && userListener != null) {
+            ref.removeEventListener(userListener);
+        }
     }
 }

--- a/app/src/main/res/layout/activity_new_chat.xml
+++ b/app/src/main/res/layout/activity_new_chat.xml
@@ -2,11 +2,34 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <EditText
+        android:id="@+id/search_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Search users" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/empty_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="No users available"
+        android:gravity="center"
+        android:visibility="gone" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/new_chat_list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- build a new-chat screen to display Firebase users
- add search field and loading states
- exclude the logged in user from the list
- add listener cleanup when the screen closes

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d6f1291d08328ae66646af3ccd0c8