### PR TITLE
Implement basic message status tracking

### DIFF
--- a/app/src/main/java/com/codespacepro/whatsify/Activities/ChatActivity.java
+++ b/app/src/main/java/com/codespacepro/whatsify/Activities/ChatActivity.java
@@ -75,6 +75,10 @@ public class ChatActivity extends AppCompatActivity {
                 for (DataSnapshot dataSnapshot : snapshot.getChildren()) {
                     Message message = dataSnapshot.getValue(Message.class);
                     if (message != null) {
+                        if (!message.getSenderId().equals(senderId) && message.getStatus() < 2) {
+                            message.setStatus(2);
+                            dataSnapshot.getRef().setValue(message);
+                        }
                         messages.add(message);
                     }
                 }
@@ -92,7 +96,7 @@ public class ChatActivity extends AppCompatActivity {
         String text = messageBox.getText().toString().trim();
         if (TextUtils.isEmpty(text)) return;
         long timestamp = System.currentTimeMillis();
-        Message message = new Message(senderId, text, timestamp);
+        Message message = new Message(senderId, text, timestamp, 0);
         String senderRoom = senderId + receiverId;
         String receiverRoom = receiverId + senderId;
         String key = messagesRef.child(senderRoom).push().getKey();

--- a/app/src/main/java/com/codespacepro/whatsify/Adapters/MessageAdapter.java
+++ b/app/src/main/java/com/codespacepro/whatsify/Adapters/MessageAdapter.java
@@ -13,6 +13,8 @@ import com.codespacepro.whatsify.Models.Message;
 import com.codespacepro.whatsify.R;
 import com.google.firebase.auth.FirebaseAuth;
 
+import java.text.DateFormat;
+import java.util.Date;
 import java.util.List;
 
 public class MessageAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
@@ -54,8 +56,10 @@ public class MessageAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         Message message = messages.get(position);
         if (holder instanceof SentViewHolder) {
             ((SentViewHolder) holder).message.setText(message.getText());
+            ((SentViewHolder) holder).info.setText(formatInfo(message));
         } else {
             ((ReceivedViewHolder) holder).message.setText(message.getText());
+            ((ReceivedViewHolder) holder).info.setText(formatInfo(message));
         }
     }
 
@@ -64,19 +68,37 @@ public class MessageAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder
         return messages.size();
     }
 
+    private String formatInfo(Message message) {
+        String time = DateFormat.getTimeInstance(DateFormat.SHORT).format(new Date(message.getTimestamp()));
+        String status;
+        switch (message.getStatus()) {
+            case 2:
+                status = "read";
+                break;
+            case 1:
+                status = "delivered";
+                break;
+            default:
+                status = "sent";
+        }
+        return time + " • " + status;
+    }
+
     static class SentViewHolder extends RecyclerView.ViewHolder {
-        TextView message;
+        TextView message, info;
         SentViewHolder(@NonNull View itemView) {
             super(itemView);
             message = itemView.findViewById(R.id.text_message_sent);
+            info = itemView.findViewById(R.id.text_message_sent_info);
         }
     }
 
     static class ReceivedViewHolder extends RecyclerView.ViewHolder {
-        TextView message;
+        TextView message, info;
         ReceivedViewHolder(@NonNull View itemView) {
             super(itemView);
             message = itemView.findViewById(R.id.text_message_received);
+            info = itemView.findViewById(R.id.text_message_received_info);
         }
     }
 }

--- a/app/src/main/java/com/codespacepro/whatsify/Models/Message.java
+++ b/app/src/main/java/com/codespacepro/whatsify/Models/Message.java
@@ -5,14 +5,16 @@ public class Message {
     private String senderId;
     private String text;
     private long timestamp;
+    private int status; // 0 sent, 1 delivered, 2 read
 
     public Message() {
     }
 
-    public Message(String senderId, String text, long timestamp) {
+    public Message(String senderId, String text, long timestamp, int status) {
         this.senderId = senderId;
         this.text = text;
         this.timestamp = timestamp;
+        this.status = status;
     }
 
     public String getMessageId() {
@@ -33,5 +35,13 @@ public class Message {
 
     public long getTimestamp() {
         return timestamp;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
     }
 }

--- a/app/src/main/res/layout/item_message_received.xml
+++ b/app/src/main/res/layout/item_message_received.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="start"
+    android:orientation="vertical"
     android:padding="8dp">
 
     <TextView
@@ -12,4 +13,13 @@
         android:background="@drawable/bg_message_received"
         android:padding="8dp"
         android:textColor="@color/black" />
+
+    <TextView
+        android:id="@+id/text_message_received_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingStart="4dp"
+        android:paddingTop="2dp"
+        android:textColor="@color/black"
+        android:textSize="12sp" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_message_sent.xml
+++ b/app/src/main/res/layout/item_message_sent.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="end"
+    android:orientation="vertical"
     android:padding="8dp">
 
     <TextView
@@ -12,4 +13,13 @@
         android:background="@drawable/bg_message_sent"
         android:padding="8dp"
         android:textColor="@color/white" />
+
+    <TextView
+        android:id="@+id/text_message_sent_info"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingStart="4dp"
+        android:paddingTop="2dp"
+        android:textColor="@color/black"
+        android:textSize="12sp" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- show timestamp and status in message rows
- add status field in `Message` model
- update chat activity to mark messages as read when loaded
- display status info in message adapter

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d77ac6d74832886523522882b38ce